### PR TITLE
Fix misspelling of lerna publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then open your browser to `http://localhost:3000`
 
 # publishing
 
-To publish your components, use `learn publish`.
+To publish your components, use `lerna publish`.
 
 You have to run it from `node_modules`.
 


### PR DESCRIPTION
My team was using `yo @walmart/electrode:component` and people were saying `learn publish` was not working.